### PR TITLE
fix ssl cert creation with too long user names or email

### DIFF
--- a/sign.8
+++ b/sign.8
@@ -21,7 +21,24 @@ sign \- sign files or rpms
 .IR hash ]
 .br
 .B sign
+.BR -g
+.IR <type> <expire> <name> <email>
+.br
+.B sign
+.BR -x
+.IR <expire> <pubkey>
+.br
+.B sign
+.BR -C
+.IR <pubkey>
+.br
+.B sign
 .B -t
+.RB [ -S
+.IR checksumfile ]
+.RB [ -T
+.IR time ]
+.br
 
 .SH DESCRIPTION
 sign adds a cryptographic signature to a file. It can add a clearsign signature
@@ -39,6 +56,12 @@ from the /etc/sign.conf file.
 
 The -k option makes sign print the keyid instead of signing a file, the
 -p option makes it print the public key.
+
+New keys can be created by using the -g option. In case a SSL certification
+is also needed (eg. for linux kernel modules) it can be created by using -C 
+option afterwards.
+
+Existing keys can be extended using -x option.
 
 .SH SECURITY
 sign needs to bind to a reserved port, it thus works only for user root

--- a/sign.c
+++ b/sign.c
@@ -3133,7 +3133,16 @@ createcert(char *pubkey)
       fprintf(stderr, "userid does not end with email\n");
       exit(1);
     }
-  name[useridl - 1] = 0;
+  if (useridl > 63)
+    {
+      /* strip name according to SSL limits, but show the striping by trailing dots */
+      name[60] = '.';
+      name[61] = '.';
+      name[62] = '.';
+      name[63] = 0;
+    } else {
+      name[useridl - 1] = 0;
+    }
   email = strrchr(name, '<');
   if (!email || email == name)
     {
@@ -3142,6 +3151,14 @@ createcert(char *pubkey)
     }
   nameend = email;
   *email++ = 0;
+  if (strlen(email) > 63)
+    {
+      /* strip email according to SSL limits, but show the striping by trailing dots */
+      email[60] = '.';
+      email[61] = '.';
+      email[62] = '.';
+      email[63] = 0;
+    }
   while (nameend > name && (nameend[-1] == ' ' || nameend[-1] == '\t'))
     *--nameend = 0;
   args[0] = "certgen";


### PR DESCRIPTION
ssl specifies a 64byte limit here, but gpg can contain longer names or email adresses