### PR TITLE
[dist] reverting commit 8e9de02f

### DIFF
--- a/dist/obssignd
+++ b/dist/obssignd
@@ -9,7 +9,7 @@
 ### BEGIN INIT INFO
 # Provides:       signd
 # Required-Start: $network $named $syslog $time
-# Should-Start:   $null $remote_fs obsstoragesetup obsapisetup
+# Should-Start:   $null $remote_fs obsstoragesetup
 # Required-Stop:  $null
 # Should-Stop:    $null
 # Default-Start:  3 5


### PR DESCRIPTION
obsstoragesetup should also create the gpg config/key, but dependency to
obsapisetup creates cycle

obsrepserver  <----------+
-> obssigner             |
   -> obssignd           |
      -> obsapisetup ----+