### PR TITLE
get rid of error: format not a string literal and no format arguments

### DIFF
--- a/sign.c
+++ b/sign.c
@@ -906,7 +906,7 @@ write_armored_signature(FILE *fp, byte *signature, int length)
   u32 crc;
   byte hash[5];
 
-  fprintf(fp, armor_signature_header);
+  fprintf(fp, "%s", armor_signature_header);
   printr64(fp, signature, length);
   crc = crc24(signature, length);
   hash[0] = crc >> 16;
@@ -914,7 +914,7 @@ write_armored_signature(FILE *fp, byte *signature, int length)
   hash[2] = crc;
   putc('=', fp);
   printr64(fp, hash, 3);
-  fprintf(fp, armor_signature_footer);
+  fprintf(fp, "%s", armor_signature_footer);
 }
 
 char *


### PR DESCRIPTION
Addressing:
```
+ gcc -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fPIC -pie -o sign sign.c
sign.c: In function 'write_armored_signature':
sign.c:909:3: error: format not a string literal and no format arguments [-Werror=format-security]
   fprintf(fp, armor_signature_header);
   ^~~~~~~
sign.c:917:3: error: format not a string literal and no format arguments [-Werror=format-security]
   fprintf(fp, armor_signature_footer);
   ^~~~~~~
```
Signed-off-by: Miroslav Suchý <msuchy@redhat.com>