### PR TITLE
Prevent problems with signing aggregated packages

### DIFF
--- a/signd
+++ b/signd
@@ -731,9 +731,9 @@ if ($cmd eq 'sign' || $cmd eq 'privsign') {
       $argv[2] = substr($argv[2], 0, -10)."0000000000";
     }
     if (@keyargs) {
-      ($status, $lout, $lerr) = rungpg('/dev/null', ["$tmpdir/privkey.$$", "$tmpdir/pubkey.$$"], $gpg, "--batch", "--force-v3-sigs", "--files-are-digests", "--allow-non-selfsigned-uid", "--digest-algo=$hashalgo", "--no-verbose", "--no-armor", "--no-secmem-warning", "--passphrase-fd=0", @keyargs, "-sbo", "-", $argv[2]);
+      ($status, $lout, $lerr) = rungpg('/dev/null', ["$tmpdir/privkey.$$", "$tmpdir/pubkey.$$"], $gpg, "--batch", "--force-v3-sigs", "--files-are-digests", "--allow-non-selfsigned-uid", "--digest-algo=$hashalgo", "--no-verbose", "--no-armor", "--no-secmem-warning", "--ignore-time-conflict", "--passphrase-fd=0", @keyargs, "-sbo", "-", $argv[2]);
     } else {
-      ($status, $lout, $lerr) = rungpg("$phrases/$user", undef, $gpg, "--batch", "--force-v3-sigs", "--files-are-digests", "--digest-algo=$hashalgo", "--no-verbose", "--no-armor", "--no-secmem-warning", "--passphrase-fd=0", "-u", $user, "-sbo", "-", $argv[2]);
+      ($status, $lout, $lerr) = rungpg("$phrases/$user", undef, $gpg, "--batch", "--force-v3-sigs", "--files-are-digests", "--digest-algo=$hashalgo", "--no-verbose", "--no-armor", "--no-secmem-warning", "--ignore-time-conflict", "--passphrase-fd=0", "-u", $user, "-sbo", "-", $argv[2]);
     }
     $lout = patchclasstime($lout, $classtime) if $classtime && !$status;
     splice(@argv, 2, 1);


### PR DESCRIPTION
Without this patch, signing of aggregated packages with signing keys newer than the package build time fails.

When OBS aggregates a package into another project,
it tries to do so using the original build time.
However, if the signing key in the new project is newer than the package build time,
this fails giving errors like this in /var/log/signer.log:

  ...
  using signtime 1505324598
  gpg: key has been created 23557508 seconds in future (time warp or clock problem)
  gpg: signing failed: Time conflict
  sign failed: 512 - checking digest
  ...

In the OBS frontend, the package will stay in the "finished" state.

Using the gpg --ignore-time-conflict option, this error is only treated as a warning.