### PR TITLE
support containerization

### DIFF
--- a/sign.8
+++ b/sign.8
@@ -160,8 +160,9 @@ Hash: either sha1 or sha256
 
 
 .SH SECURITY
-sign needs to bind to a reserved port, it thus works only for user root
-or needs to be installed suid-root. If the latter is the case, sign
+Unless the allow-unprivileged-ports option has been set to true for signd,
+sign needs to bind to a reserved port, in which case it works only for user
+root or needs to be installed suid-root. If the latter is the case, sign
 grants the users specified in the "allowuser" lines of the configuration
 the right to sign files.
 

--- a/sign.conf.5
+++ b/sign.conf.5
@@ -32,8 +32,13 @@ Set a default user to use for signing.
 Set a default hash to use for signing. The default hash
 is SHA1.
 .TP 4
-.BR allow: " ip1 ip2 ip3..."
-Allow only connections from the specified ip addresses.
+.BR allow: " ip subnet hostname..."
+Allow only connections from the specified ip addresses,
+subnets expressed in CIDR notation, and/or hostnames.
+Note that hostnames are resolved using reverse DNS
+lookups, so there must be reverse entries in the DNS
+server, and it should be secured against DNS poisoning
+attacks.
 Must be present.
 .TP 4
 .BR gpg: " path_to_gpg"
@@ -53,6 +58,11 @@ Grant the user the right to sign. the sign binary must
 be installed suid-root for this to work. Multiple
 users can be specified by using multiple allowuser
 lines in the configuration.
+.TP 4
+.BR allow-unprivileged-ports: " true|false"
+Allow signd to accept connections from source ports >
+1024.
+Defaults to false.
 
 .SH FILES
 .I /etc/sign.conf

--- a/signd
+++ b/signd
@@ -20,7 +20,7 @@
 
 use strict;
 use warnings;
-use Socket qw/IPPROTO_TCP PF_INET SOCK_STREAM SOL_SOCKET SO_REUSEADDR SO_KEEPALIVE INADDR_ANY inet_aton inet_ntoa sockaddr_in/;
+use Socket qw/IPPROTO_TCP PF_INET SOCK_STREAM SOL_SOCKET SO_REUSEADDR SO_KEEPALIVE INADDR_ANY inet_aton inet_ntoa sockaddr_in getnameinfo/;
 use POSIX;
 use Math::BigInt;
 use MIME::Base64;
@@ -29,7 +29,7 @@ use bytes;
 use File::Temp qw/tempdir/;
 use File::Path qw/remove_tree/;
 
-my %allow;
+my @allows;
 my %map;
 my $signhost = '127.0.0.1';
 my $port = 5167;
@@ -41,6 +41,7 @@ my $phrases = '';
 my $tmpdir = '/var/run/signd';
 my $patchclasstime;
 my $conf = '/etc/sign.conf';
+my $allow_unprivileged_ports = 0;
 
 # request data
 my $oldproto = 0;
@@ -52,6 +53,31 @@ sub printlog {
   my $year = $lt[5] + 1900;
   my $month = $lt[4] + 1;
   printf "%04d-%02d-%02d %02d:%02d:%02d: %s\n", $year, $month, @lt[3,2,1,0], $msg;
+}
+
+# convert CIDR prefix to netmask array
+sub calc_netmask {
+  my $prefix = @_;
+  my $mask  = (2 ** $prefix - 1) << (32 - $prefix);
+  my @netmask = unpack( "C4", pack( "N", $mask ) );
+  return @netmask;
+}
+
+# Check if an ip falls within a CIDR-style subnet
+sub ip_in_network {
+  return 0 if !$_[0] || !$_[1];
+  my @ip_a = split '\.', $_[0];
+  my @network_a = split '\.', $_[1];
+  my @netmask_a = calc_netmask($_[2]);
+  my $in_network = 1;
+  for (my $i = 0; $i < 4; $i++) {
+    my $top_octet = $network_a[$i] + (255 - $netmask_a[$i]);
+    if ($ip_a[$i] < $network_a[$i] || $ip_a[$i] > $top_octet) {
+      $in_network = 0;
+      last;
+    }
+  }
+  return $in_network;
 }
 
 sub decodetaglenoff {
@@ -319,7 +345,7 @@ while(<F>) {
   }
   if ($s[0] eq 'allow:') {
     shift @s;
-    $allow{$_} = 1 for @s;
+    push @allows, $_ for @s;
     next;
   }
   if ($s[0] eq 'map:') {
@@ -349,6 +375,11 @@ while(<F>) {
   if ($s[0] eq 'patchclasstime:') {
     $patchclasstime = $s[1];
     next;
+  }
+  if ($s[0] eq 'allow-unprivileged-ports:') {
+    if ($s[1] =~ /^(true|false)$/i) {
+      $allow_unprivileged_ports = lc $1 eq 'true';
+    }
   }
 }
 
@@ -424,8 +455,18 @@ $SIG{'__DIE__'} = sub {
 
 my ($sport, $saddr) = sockaddr_in($clntaddr);
 $peer = inet_ntoa($saddr);
-die("not coming from a reserved port\n") if $sport < 0 || $sport > 1024;
-die("illegal host $peer\n") unless $allow{$peer};
+die("not coming from a reserved port\n") if !$allow_unprivileged_ports &&
+  ($sport < 0 || $sport > 1024);
+my $allowed = 0;
+my ($hosterr, $hostname, $servicename) = getnameinfo($clntaddr);
+foreach my $allow (@allows) {
+  $allow =~ /([0-9\.]+)\/([0-9]+)/;
+  if (ip_in_network($peer, $1, $2) || $peer eq $allow || $hostname eq $allow) {
+    $allowed = 1;
+    last;
+  }
+}
+die("illegal host $peer\n") unless $allowed;
 
 # read request from client, split into argv array
 sub readreq {

--- a/signd.8
+++ b/signd.8
@@ -17,8 +17,10 @@ It needs a gpg implementation that understands the
 "--files-are-digests" option to work correctly.
 
 .SH SECURITY
-signd allows only connections from reserved ports and ip
-addresses listed in the "allow" field of the configuration.
+Unless the allow-unprivileged-ports option is set to true in
+/etc/sign.conf, signd allows only connections from reserved ports
+and the ip addresses, subnets expressed in CIDR notation, and
+hostnames listed in the "allow" field of the configuration.
 
 .SH SEE ALSO
 .BR sign (8),


### PR DESCRIPTION
This PR adds support for a few different things, which are useful if `signd` is running in a containerized environment. I'm not sure if any will be accepted due to the security implications, but I figured I'd try my luck.

1. Add parameter `allow-unprivileged-ports`, which defaults to false. As you can probably guess from the name, it allows requests to come from an unprivileged port.
2. Accept subnets in CIDR notation in the `allow` field of the config, e.g. `172.17.0.0/16`. The incoming IP is then checked against the subnet to ensure it is within the subnet.
3. Accept hostnames in the `allow` field of the config, e.g. `my-host.my-domain.com`. This is queried with `getnameinfo` at request time to check if it should be allowed as per the `allow` field.

Please let me know if you'd be willing to accept any or all of the changes.