### PR TITLE
default GNUPGHOME set to /srv/obs/gnupg

### DIFF
--- a/dist/obs-signd.spec
+++ b/dist/obs-signd.spec
@@ -104,7 +104,7 @@ install -m 0644 dist/sysconfig.signd $FILLUP_DIR/
 %else
 %run_permissions
 %endif
-%fillup_only
+%fillup_only -n signd
 
 %postun
 %service_del_postun obssignd.service

--- a/dist/signd.service
+++ b/dist/signd.service
@@ -5,6 +5,7 @@ After=syslog.target
 [Service]
 Type=forking
 PIDFile=/var/run/signd.pid
+EnvironmentFile=-/etc/sysconfig/signd
 ExecStart=/usr/sbin/signd -f
 Restart=on-abort
 

--- a/dist/sysconfig.signd
+++ b/dist/sysconfig.signd
@@ -1,10 +1,9 @@
 ## Path:        Applications/OBS
 ## Description: Define gpgp home directory for signing daemon
 ## Type:        string
-## Default:     ""
+## Default:     "/srv/obs/gnupg"
 ## Config:      OBS
 #
 # An empty setting will lead to a check for /obs/gnupg or /srv/obs/gnupg
 #
-OBS_SIGND_GNUPG_HOME=""
-
+GNUPGHOME="/srv/obs/gnupg"


### PR DESCRIPTION
Without this patch obssignd cannot sign anymore because it is missing the
proper GNUPGHOME environment variable

* This patch fixes %fillup_only to ensures that a file /etc/sysconfig/signd is
  created.
* The variable "OBS_SIGND_GNUPG_HOME" was dropped in favour of "GNUPGHOME".
* systemd service reads /etc/sysconfig/signd (if exists)