### PR TITLE
man: document default for -h

### DIFF
--- a/sign.8
+++ b/sign.8
@@ -178,6 +178,13 @@ Print the keyid of signd key-pair (root key or defined by \-u)
 .TP
 .BR \-p
 Print pubkey of signd key-pair (root key or defined by \-u)
+.TP
+.BR \-u
+Username, signd should already know about that user
+.TP
+.BR \-h
+Hash: either sha1 or sha256. Default is sha1, because some old distributions,
+e.g., RHEL 7, cannot handle sha256. On modern systems you should use sha256.
 
 
 .SH SECURITY


### PR DESCRIPTION
Relates to https://github.com/openSUSE/obs-sign/issues/34