### PR TITLE
Implement 'allow-unprivileged-ports' for the client

### DIFF
--- a/sign.c
+++ b/sign.c
@@ -38,6 +38,7 @@
 char *host;
 int port = MYPORT;
 char *test_sign;
+int allow_unprivileged_ports = 0;
 static char *user;
 static char *algouser;
 static int allowuser;
@@ -1209,6 +1210,11 @@ read_sign_conf(const char *conf)
 	    hashalgo = HASH_SHA512;
 	  else
 	    dodie("sign.conf: unsupported hash argument");
+	}
+      if (!strcmp(buf, "allow-unprivileged-ports"))
+	{
+	  if (!strcmp(bp, "true"))
+	    allow_unprivileged_ports = 1;
 	}
       if (uid && !allowuser && !strcmp(buf, "allowuser"))
 	{


### PR DESCRIPTION
The restricted rootless container environment (e.g. OpenShift) doesn't
allow us to call seteuid(), call setuid binaries, or bind to privileged
ports.  Therefore we need to have some opt-out for the use of privileged
ports.

With the very same option, the signd-side can already accept
such connections (before the option was useful when the source port was
changed to a non-privileged one, e.g. by some proxy).