### PR TITLE
init-script use default type simple and do not fork

### DIFF
--- a/dist/signd.service
+++ b/dist/signd.service
@@ -3,10 +3,9 @@ Description=GPG Sign Daemon
 After=syslog.target obsapisetup.service
 
 [Service]
-Type=forking
 PIDFile=/run/signd.pid
 EnvironmentFile=-/etc/sysconfig/signd
-ExecStart=/usr/sbin/signd -f
+ExecStart=/usr/sbin/signd
 Restart=on-abort
 
 [Install]


### PR DESCRIPTION
systemd units should normally not fork to the background